### PR TITLE
Update readme.md

### DIFF
--- a/caddy_v2/readme.md
+++ b/caddy_v2/readme.md
@@ -473,7 +473,7 @@ Like so:
 
 ```
 nextcloud.{$MY_DOMAIN} {
-    reverse_proxy nextcloud:80
+    reverse_proxy nextcloud-web:80
     header Strict-Transport-Security max-age=31536000;
     redir /.well-known/carddav /remote.php/carddav 301
     redir /.well-known/caldav /remote.php/caldav 301


### PR DESCRIPTION
I noticed that the suggested configuration for the Caddyfile is slightly different in https://github.com/DoTheEvo/selfhosted-apps-docker/tree/master/caddy_v2#hsts-and-redirects, the following is suggested: 

```
nextcloud.{$MY_DOMAIN} {
    reverse_proxy nextcloud:80
    header Strict-Transport-Security max-age=31536000;
    redir /.well-known/carddav /remote.php/carddav 301
    redir /.well-known/caldav /remote.php/caldav 301
}
```
Which is slightly different than the correct configuration, which is https://github.com/DoTheEvo/selfhosted-apps-docker/tree/master/nextcloud#reverse-proxy: 

```
nextcloud.{$MY_DOMAIN} {
    reverse_proxy nextcloud-web:80
    header Strict-Transport-Security max-age=31536000;
    redir /.well-known/carddav /remote.php/carddav 301
    redir /.well-known/caldav /remote.php/caldav 301
}
```
Using the former configuration will result in an error when trying to access the Nextcloud subdomain:

`{"level":"error","ts":1591724543.1679618,"logger":"http.log.error","msg":"dial tcp: lookup nextcloud on 127.0.0.11:53: no such host"`